### PR TITLE
Path Combat accumulating for Red Correction

### DIFF
--- a/jsons/automation.json
+++ b/jsons/automation.json
@@ -113,7 +113,6 @@
                         ["IN_STRING", "$TARGET.parentCards.[0].sides.B.name", "Path"],
                         [
                             ["SET", "/groupById/$TARGET.activeBlueGroupId/combatStat", "pathCombat"],
-                            ["SET", "/groupById/$TARGET.activeRedGroupId/combatStat", "pathCombat"],
                             ["SET", "/groupById/$TARGET.activeBlueGroupId/combatToken", "pathBlue"],
                             ["SET", "/groupById/$TARGET.activeRedGroupId/combatToken", "pathRed"]
                         ],


### PR DESCRIPTION
Path cards that have a predefined PathCombat defense on the card are incorrectly accumulating for Red.  

The tokens are now accumulating correcting but that updated had a bug that allowed PathCombat Defense to contribute for Red as well.  Since no PathCombat values for Red exist on Paths, this should be the final correction to resolve the Path Red Attack Token issue.